### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.12.1
+RUN CGO_ENABLED=0 go get github.com/soundcloud/ipmi_exporter
+
+FROM debian:stable-slim
+RUN apt-get update && \
+    apt-get install -y freeipmi && \
+    rm -r /var/lib/apt/lists/*
+COPY --from=0 /go/bin/ipmi_exporter /usr/local/bin/
+EXPOSE 9290
+ENTRYPOINT [ "ipmi_exporter" ]


### PR DESCRIPTION
The Dockerfile uses a git clone and not a local copy. IDK if that is the way you want to do it you could do a 
```
COPY . /go/src/github.com/soundcloud/ipmi_exporter/
```
instead and then run a `go install github.com/soundcloud/ipmi_exporter`. Depends on your CI infrastructure?
